### PR TITLE
[TestUnifiedPipeline] Move serverVulnerabilityAssessment API to stable-2020-01-01

### DIFF
--- a/specification/security/resource-manager/readme.md
+++ b/specification/security/resource-manager/readme.md
@@ -152,10 +152,11 @@ input-file:
 - Microsoft.Security/preview/2017-08-01-preview/securityContacts.json
 - Microsoft.Security/preview/2017-08-01-preview/workspaceSettings.json
 - Microsoft.Security/preview/2019-01-01-preview/regulatoryCompliance.json
-- Microsoft.Security/preview/2019-01-01-preview/serverVulnerabilityAssessments.json
+
 - Microsoft.Security/preview/2019-01-01-preview/subAssessments.json
 - Microsoft.Security/preview/2019-01-01-preview/automations.json
 - Microsoft.Security/preview/2019-01-01-preview/alertsSuppressionRules.json
+- Microsoft.Security/stable/2020-01-01/serverVulnerabilityAssessments.json
 - Microsoft.Security/stable/2020-01-01/assessmentMetadata.json
 - Microsoft.Security/stable/2020-01-01/assessments.json
 - Microsoft.Security/stable/2020-01-01/applicationWhitelistings.json
@@ -225,7 +226,6 @@ These settings apply only when `--tag=package-2019-01-preview-only` is specified
 ``` yaml $(tag) == 'package-2019-01-preview-only'
 input-file:
 - Microsoft.Security/preview/2019-01-01-preview/regulatoryCompliance.json
-- Microsoft.Security/preview/2019-01-01-preview/serverVulnerabilityAssessments.json
 - Microsoft.Security/preview/2019-01-01-preview/alertsSuppressionRules.json
 - Microsoft.Security/preview/2019-01-01-preview/assessmentMetadata.json
 - Microsoft.Security/preview/2019-01-01-preview/assessments.json
@@ -391,7 +391,7 @@ input-file:
   - $(this-folder)/Microsoft.Security/stable/2019-08-01/deviceSecurityGroups.json
   - $(this-folder)/Microsoft.Security/stable/2019-08-01/iotSecuritySolutions.json
   - $(this-folder)/Microsoft.Security/stable/2019-08-01/iotSecuritySolutionAnalytics.json
-  - $(this-folder)/Microsoft.Security/preview/2019-01-01-preview/serverVulnerabilityAssessments.json
+  - $(this-folder)/Microsoft.Security/stable/2020-01-01/serverVulnerabilityAssessments.json
   - $(this-folder)/Microsoft.Security/stable/2020-01-01/assessmentMetadata.json
   - $(this-folder)/Microsoft.Security/stable/2020-01-01/assessments.json
   - $(this-folder)/Microsoft.Security/stable/2020-01-01/applicationWhitelistings.json


### PR DESCRIPTION
Mirror from `https://github.com/Azure/azure-rest-api-specs/pull/9097`