### PR TITLE
[TestUnifiedPipeline] Removed description as a required field for SearchIndexerSkillset

### DIFF
--- a/specification/search/data-plane/Azure.Search/preview/2019-05-06-preview/searchservice.json
+++ b/specification/search/data-plane/Azure.Search/preview/2019-05-06-preview/searchservice.json
@@ -6830,7 +6830,6 @@
       },
       "required": [
         "name",
-        "description",
         "skills"
       ],
       "externalDocs": {


### PR DESCRIPTION
Mirror from `https://github.com/Azure/azure-rest-api-specs/pull/9588`