### PR TITLE
[TestUnifiedPipeline] TranslatorText: fixed "score" field type

### DIFF
--- a/specification/cognitiveservices/data-plane/TranslatorText/stable/v3.0/TranslatorText.json
+++ b/specification/cognitiveservices/data-plane/TranslatorText/stable/v3.0/TranslatorText.json
@@ -894,7 +894,8 @@
                 "type": "string"
               },
               "score": {
-                "type": "float"
+                "type": "number",
+                "format": "float"
               }
             }
           },


### PR DESCRIPTION
Mirror from `https://github.com/Azure/azure-rest-api-specs/pull/9380`