### PR TITLE
[TestTargetMaster] Renamed SmbSettings and ProtocolSettings, Removed lease duration headers. 

### DIFF
--- a/specification/storage/data-plane/Microsoft.FileStorage/preview/2020-02-10/file.json
+++ b/specification/storage/data-plane/Microsoft.FileStorage/preview/2020-02-10/file.json
@@ -5285,13 +5285,13 @@
                 "name": "Range"
             }
         },
-        "ProtocolSettings": {
+        "ShareProtocolSettings": {
             "description": "Protocol settings",
             "type": "object",
             "properties": {
-                "SmbSettings": {
+                "Smb": {
                     "description": "Settings for SMB protocol.",
-                    "$ref": "#/definitions/SmbSettings",
+                    "$ref": "#/definitions/ShareSmbSettings",
                     "xml": {
                         "name": "SMB"
                     }
@@ -5462,7 +5462,7 @@
                 "name": "SignedIdentifiers"
             }
         },
-        "SmbSettings": {
+        "ShareSmbSettings": {
             "description": "Settings for SMB protocol.",
             "type": "object",
             "properties": {
@@ -5494,9 +5494,12 @@
                         "wrapped": true
                     }
                 },
-                "ProtocolSettings": {
+                "Protocol": {
                     "description": "Protocol settings",
-                    "$ref":"#/definitions/ProtocolSettings"
+                    "$ref":"#/definitions/ShareProtocolSettings",
+                    "xml": {
+                        "name": "ProtocolSettings"
+                    }
                 }
             }
         },


### PR DESCRIPTION
Mirror from `https://github.com/Azure/azure-rest-api-specs/pull/10835`