### PR TITLE
[TestUnifiedPipeline] Customer assigned PlatformFaultDomain on VM creation when it references a VMSS

### DIFF
--- a/specification/compute/resource-manager/readme.md
+++ b/specification/compute/resource-manager/readme.md
@@ -216,7 +216,7 @@ These settings apply only when `--tag=package-2020-12-01` is specified on the co
 ``` yaml $(tag) == 'package-2020-12-01'
 input-file:
 - Microsoft.Compute/stable/2020-12-01/compute.json
-- Microsoft.Compute/stable/2020-06-01/runCommands.json
+- Microsoft.Compute/stable/2020-12-01/runCommands.json
 - Microsoft.Compute/stable/2019-04-01/skus.json
 - Microsoft.Compute/stable/2020-06-30/disk.json
 - Microsoft.Compute/preview/2020-09-30/gallery.json
@@ -231,6 +231,7 @@ These settings apply only when `--tag=package-2020-12-01-only` is specified on t
 ``` yaml $(tag) == 'package-2020-12-01-only'
 input-file:
 - Microsoft.Compute/stable/2020-12-01/compute.json
+- Microsoft.Compute/stable/2020-12-01/runCommands.json
 ```
 ### Tag: package-2020-09-30
 


### PR DESCRIPTION
Mirror from `https://github.com/Azure/azure-rest-api-specs/pull/11409`