### PR TITLE
DO NOT MERGE: TEST PR. Update wayfind.json to test ParameterLocationHasChanged

### DIFF
--- a/specification/maps/data-plane/Creator/preview/2022-09-01-preview/wayfind.json
+++ b/specification/maps/data-plane/Creator/preview/2022-09-01-preview/wayfind.json
@@ -176,7 +176,7 @@
       "in": "query",
       "required": true,
       "default": "2022-09-01-preview",
-      "x-ms-parameter-location": "client"
+      "x-ms-parameter-location": "method"
     },
     "RoutesetId": {
       "name": "routesetId",


### PR DESCRIPTION
Test if rule 1050 `ParameterLocationHasChanged` triggers. It was implemented by:
- https://github.com/Azure/openapi-diff/pull/334