### PR TITLE
DNR `brInfo_cross_ver_brch` branch

### DIFF
--- a/BRANCH_INFO.md
+++ b/BRANCH_INFO.md
@@ -1,0 +1,47 @@
+This branch was created by kojamroz on 6/26/2024
+
+This branch is expected to trigger cross-version breaking change report between stable version. 
+In addition, the TypeSpec requirement check should not trigger.
+
+It differs from main as follows:
+
+## 1. It introduces a new directory:
+
+`specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2024-05-01`
+
+which is a copy of:
+
+`specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2023-03-01`
+
+## 2. In the new directory the following file:
+
+`specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2024-05-01/PrometheusRuleGroups.json`
+
+Differs from its original. Its `operationId` has been changed. It is now:
+
+`"operationId": "CROSS_VER_BREAKING_CHANGE_TEST_PrometheusRuleGroups_ListBySubscription",`
+
+instead of the original:
+
+`"operationId": "PrometheusRuleGroups_ListBySubscription",`
+
+In addition, all files in the newly introduced directory got their `"version"` updated to be `"2024-05-01"`.
+
+## 3. The README:
+
+`specification/alertsmanagement/resource-manager/readme.md`
+
+The default tag has been changed to `package-2024-05` and following entry was added:
+
+> Tag: package-2024-05
+> 
+> These settings apply only when `--tag=package-2024-05` is specified on the command line.
+>
+> ```yaml $(tag) == 'package-2023-03'
+> input-file:
+>   - Microsoft.AlertsManagement/stable/2024-05-01/PrometheusRuleGroups.json
+>   - Microsoft.AlertsManagement/preview/2024-01-01-preview/AlertsManagement.json
+>   - Microsoft.AlertsManagement/preview/2019-05-05-preview/SmartGroups.json
+>   - Microsoft.AlertsManagement/preview/2023-08-01-preview/AlertRuleRecommendations.json
+>   - Microsoft.AlertsManagement/preview/2024-03-01-preview/AlertProcessingRules.json
+> ```

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2024-05-01/PrometheusRuleGroups.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2024-05-01/PrometheusRuleGroups.json
@@ -1,0 +1,508 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "2024-05-01",
+    "title": "Azure Alerts Management Service Resource Provider",
+    "description": "Azure Alerts Management Service provides a single pane of glass of alerts across Azure Monitor."
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.AlertsManagement/prometheusRuleGroups": {
+      "get": {
+        "tags": [
+          "PrometheusRuleGroups"
+        ],
+        "description": "Retrieve Prometheus all rule group definitions in a subscription.",
+        "operationId": "CROSS_VER_BREAKING_CHANGE_TEST_PrometheusRuleGroups_ListBySubscription",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful request for a list of Prometheus rule groups",
+            "schema": {
+              "$ref": "#/definitions/PrometheusRuleGroupResourceCollection"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": null
+        },
+        "x-ms-examples": {
+          "List Subscription Resource PrometheusRuleGroups": {
+            "$ref": "./examples/listSubscriptionPrometheusRuleGroups.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AlertsManagement/prometheusRuleGroups": {
+      "get": {
+        "tags": [
+          "PrometheusRuleGroups"
+        ],
+        "description": "Retrieve Prometheus rule group definitions in a resource group.",
+        "operationId": "PrometheusRuleGroups_ListByResourceGroup",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful request for a list of Prometheus rule groups",
+            "schema": {
+              "$ref": "#/definitions/PrometheusRuleGroupResourceCollection"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": null
+        },
+        "x-ms-examples": {
+          "List Resource group PrometheusRuleGroups": {
+            "$ref": "./examples/listPrometheusRuleGroups.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AlertsManagement/prometheusRuleGroups/{ruleGroupName}": {
+      "get": {
+        "tags": [
+          "PrometheusRuleGroups"
+        ],
+        "description": "Retrieve a Prometheus rule group definition.",
+        "operationId": "PrometheusRuleGroups_Get",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/RuleGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful request for a list of Prometheus rule groups",
+            "schema": {
+              "$ref": "#/definitions/PrometheusRuleGroupResource"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get a PrometheusRuleGroup": {
+            "$ref": "./examples/getPrometheusRuleGroup.json"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "PrometheusRuleGroups"
+        ],
+        "description": "Create or update a Prometheus rule group definition.",
+        "operationId": "PrometheusRuleGroups_CreateOrUpdate",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/RuleGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PrometheusRuleGroupResource"
+            },
+            "description": "The parameters of the rule group to create or update."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK (Updated).",
+            "schema": {
+              "$ref": "#/definitions/PrometheusRuleGroupResource"
+            }
+          },
+          "201": {
+            "description": "Created (New Alert rule was created).",
+            "schema": {
+              "$ref": "#/definitions/PrometheusRuleGroupResource"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create or Update a PrometheusRuleGroup": {
+            "$ref": "./examples/createOrUpdatePrometheusRuleGroup.json"
+          },
+          "Create or Update a cluster centric PrometheusRuleGroup": {
+            "$ref": "./examples/createOrUpdateClusterCentricRuleGroup.json"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "PrometheusRuleGroups"
+        ],
+        "description": "Update an Prometheus rule group definition.",
+        "operationId": "PrometheusRuleGroups_Update",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/RuleGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PrometheusRuleGroupResourcePatchParameters"
+            },
+            "description": "The parameters of the rule group to update."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/PrometheusRuleGroupResource"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Patch a PrometheusRuleGroup": {
+            "$ref": "./examples/patchPrometheusRuleGroup.json"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "PrometheusRuleGroups"
+        ],
+        "description": "Delete a Prometheus rule group definition.",
+        "operationId": "PrometheusRuleGroups_Delete",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/RuleGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful request to delete a Prometheus rule group"
+          },
+          "204": {
+            "description": "No content: the request was successful, but the response is empty"
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete a PrometheusRuleGroup": {
+            "$ref": "./examples/deletePrometheusRuleGroup.json"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "PrometheusRuleGroupResource": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/TrackedResource"
+        }
+      ],
+      "required": [
+        "properties"
+      ],
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/PrometheusRuleGroupProperties",
+          "description": "The Prometheus rule group properties of the resource."
+        }
+      },
+      "description": "The Prometheus rule group resource."
+    },
+    "PrometheusRuleGroupResourcePatchParameters": {
+      "type": "object",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Resource tags"
+        },
+        "properties": {
+          "type": "object",
+          "x-ms-client-flatten": true,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "the flag that indicates whether the Prometheus rule group is enabled."
+            }
+          }
+        }
+      },
+      "description": "The Prometheus rule group resource for patch operations."
+    },
+    "PrometheusRuleGroupResourceCollection": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PrometheusRuleGroupResource"
+          },
+          "description": "the values for the alert rule resources."
+        }
+      },
+      "description": "Represents a collection of alert rule resources."
+    },
+    "PrometheusRuleGroupProperties": {
+      "description": "An Azure Prometheus rule group.",
+      "type": "object",
+      "required": [
+        "scopes",
+        "rules"
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Rule group description."
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable/disable rule group."
+        },
+        "clusterName": {
+          "type": "string",
+          "description": "Apply rule to data from a specific cluster."
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Target Azure Monitor workspaces resource ids. This api-version is currently limited to creating with one scope. This may change in future."
+        },
+        "interval": {
+          "type": "string",
+          "description": "The interval in which to run the Prometheus rule group represented in ISO 8601 duration format. Should be between 1 and 15 minutes",
+          "format": "duration"
+        },
+        "rules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PrometheusRule"
+          },
+          "description": "Defines the rules in the Prometheus rule group.",
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "PrometheusRule": {
+      "type": "object",
+      "description": "An Azure Prometheus alerting or recording rule.",
+      "required": [
+        "expression"
+      ],
+      "properties": {
+        "record": {
+          "description": "Recorded metrics name.",
+          "type": "string"
+        },
+        "alert": {
+          "description": "Alert rule name.",
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable/disable rule."
+        },
+        "expression": {
+          "description": "The PromQL expression to evaluate. https://prometheus.io/docs/prometheus/latest/querying/basics/. Evaluated periodically as given by 'interval', and the result recorded as a new set of time series with the metric name as given by 'record'.",
+          "type": "string"
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Labels to add or overwrite before storing the result."
+        },
+        "severity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The severity of the alerts fired by the rule. Must be between 0 and 4."
+        },
+        "for": {
+          "type": "string",
+          "description": "The amount of time alert must be active before firing.",
+          "format": "duration"
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The annotations clause specifies a set of informational labels that can be used to store longer additional information such as alert descriptions or runbook links. The annotation values can be templated."
+        },
+        "actions": {
+          "$ref": "#/definitions/PrometheusRuleGroupActions",
+          "description": "Actions that are performed when the alert rule becomes active, and when an alert condition is resolved."
+        },
+        "resolveConfiguration": {
+          "$ref": "#/definitions/PrometheusRuleResolveConfiguration",
+          "description": "Defines the configuration for resolving fired alerts. Only relevant for alerts."
+        }
+      }
+    },
+    "PrometheusRuleGroupActions": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PrometheusRuleGroupAction"
+      },
+      "x-ms-identifiers": [],
+      "description": "The array of actions that are performed when the alert rule becomes active, and when an alert condition is resolved. Only relevant for alerts."
+    },
+    "PrometheusRuleGroupAction": {
+      "type": "object",
+      "description": "An alert action. Only relevant for alerts.",
+      "properties": {
+        "actionGroupId": {
+          "type": "string",
+          "description": "The resource id of the action group to use."
+        },
+        "actionProperties": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The properties of an action group object."
+        }
+      }
+    },
+    "PrometheusRuleResolveConfiguration": {
+      "type": "object",
+      "description": "Specifies the Prometheus alert rule configuration.",
+      "properties": {
+        "autoResolved": {
+          "type": "boolean",
+          "description": "Enable alert auto-resolution."
+        },
+        "timeToResolve": {
+          "type": "string",
+          "description": "Alert auto-resolution timeout.",
+          "format": "duration"
+        }
+      }
+    }
+  },
+  "parameters": {
+    "RuleGroupNameParameter": {
+      "name": "ruleGroupName",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The name of the rule group.",
+      "x-ms-parameter-location": "method",
+      "pattern": "^[^:@/#{}%&+*<>?]+$"
+    }
+  }
+}

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2024-05-01/examples/createOrUpdateClusterCentricRuleGroup.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2024-05-01/examples/createOrUpdateClusterCentricRuleGroup.json
@@ -1,0 +1,116 @@
+{
+  "parameters": {
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+    "resourceGroupName": "promResourceGroup",
+    "ruleGroupName": "myPrometheusRuleGroup",
+    "api-version": "2024-05-01",
+    "parameters": {
+      "location": "East US",
+      "properties": {
+        "description": "This is a rule group with culster centric configuration",
+        "interval": "PT10M",
+        "clusterName": "myClusterName",
+        "scopes": [
+          "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/myResourceGroup/providers/microsoft.monitor/accounts/myAzureMonitorWorkspace",
+          "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/myResourceGroup/providers/Microsoft.ContainerService/managedClusters/myClusterName"
+        ],
+        "rules": [
+          {
+            "alert": "Billing_Processing_Very_Slow",
+            "expression": "job_type:billing_jobs_duration_seconds:99p5m > 30",
+            "enabled": true,
+            "severity": 2,
+            "for": "PT5M",
+            "labels": {
+              "team": "prod"
+            },
+            "annotations": {
+              "annotationName1": "annotationValue1"
+            },
+            "resolveConfiguration": {
+              "autoResolved": true,
+              "timeToResolve": "PT10M"
+            },
+            "actions": []
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/promResourceGroup/providers/Microsoft.AlertsManagement/prometheusRuleGroups/myPrometheusRuleGroup",
+        "type": "Microsoft.AlertsManagement/prometheusRuleGroups",
+        "location": "East US",
+        "properties": {
+          "description": "This is a rule group with culster centric configuration",
+          "interval": "PT10M",
+          "clusterName": "myClusterName",
+          "scopes": [
+            "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/myResourceGroup/providers/microsoft.monitor/accounts/myAzureMonitorWorkspace",
+            "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/myResourceGroup/providers/Microsoft.ContainerService/managedClusters/myClusterName"
+          ],
+          "rules": [
+            {
+              "alert": "Billing_Processing_Very_Slow",
+              "expression": "job_type:billing_jobs_duration_seconds:99p5m > 30",
+              "enabled": true,
+              "severity": 2,
+              "for": "PT5M",
+              "labels": {
+                "team": "prod"
+              },
+              "annotations": {
+                "annotationName1": "annotationValue1"
+              },
+              "resolveConfiguration": {
+                "autoResolved": true,
+                "timeToResolve": "PT10M"
+              },
+              "actions": []
+            }
+          ]
+        }
+      }
+    },
+    "201": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/promResourceGroup/providers/Microsoft.AlertsManagement/prometheusRuleGroups/myPrometheusRuleGroup",
+        "type": "Microsoft.AlertsManagement/prometheusRuleGroups",
+        "location": "East US",
+        "properties": {
+          "description": "This is a rule group with culster centric configuration",
+          "interval": "PT10M",
+          "clusterName": "myClusterName",
+          "scopes": [
+            "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/myResourceGroup/providers/microsoft.monitor/accounts/myAzureMonitorWorkspace",
+            "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/myResourceGroup/providers/Microsoft.ContainerService/managedClusters/myClusterName"
+          ],
+          "rules": [
+            {
+              "alert": "Billing_Processing_Very_Slow",
+              "expression": "job_type:billing_jobs_duration_seconds:99p5m > 30",
+              "enabled": true,
+              "severity": 2,
+              "for": "PT5M",
+              "labels": {
+                "team": "prod"
+              },
+              "annotations": {
+                "annotationName1": "annotationValue1"
+              },
+              "resolveConfiguration": {
+                "autoResolved": true,
+                "timeToResolve": "PT10M"
+              },
+              "actions": []
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2024-05-01/examples/createOrUpdatePrometheusRuleGroup.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2024-05-01/examples/createOrUpdatePrometheusRuleGroup.json
@@ -1,0 +1,182 @@
+{
+  "parameters": {
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+    "resourceGroupName": "promResourceGroup",
+    "ruleGroupName": "myPrometheusRuleGroup",
+    "api-version": "2024-05-01",
+    "parameters": {
+      "location": "East US",
+      "properties": {
+        "description": "This is the description of the following rule group",
+        "enabled": true,
+        "interval": "PT10M",
+        "clusterName": "myClusterName",
+        "scopes": [
+          "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/myResourceGroup/providers/microsoft.monitor/accounts/myAzureMonitorWorkspace"
+        ],
+        "rules": [
+          {
+            "record": "job_type:billing_jobs_duration_seconds:99p5m",
+            "expression": "histogram_quantile(0.99, sum(rate(jobs_duration_seconds_bucket{service=\"billing-processing\"}[5m])) by (job_type))",
+            "labels": {
+              "team": "prod"
+            }
+          },
+          {
+            "alert": "Billing_Processing_Very_Slow",
+            "expression": "job_type:billing_jobs_duration_seconds:99p5m > 30",
+            "enabled": true,
+            "severity": 2,
+            "for": "PT5M",
+            "labels": {
+              "team": "prod"
+            },
+            "annotations": {
+              "annotationName1": "annotationValue1"
+            },
+            "resolveConfiguration": {
+              "autoResolved": true,
+              "timeToResolve": "PT10M"
+            },
+            "actions": [
+              {
+                "actionGroupId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourcegroups/myrg/providers/microsoft.insights/actiongroups/myactiongroup",
+                "actionProperties": {
+                  "key11": "value11",
+                  "key12": "value12"
+                }
+              },
+              {
+                "actionGroupId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourcegroups/myrg/providers/microsoft.insights/actiongroups/myotheractiongroup",
+                "actionProperties": {
+                  "key21": "value21",
+                  "key22": "value22"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/promResourceGroup/providers/Microsoft.AlertsManagement/prometheusRuleGroups/myPrometheusRuleGroup",
+        "type": "Microsoft.AlertsManagement/prometheusRuleGroups",
+        "location": "East US",
+        "properties": {
+          "description": "This is the description of the following rule group",
+          "enabled": true,
+          "interval": "PT10M",
+          "clusterName": "myClusterName",
+          "scopes": [
+            "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/myResourceGroup/providers/microsoft.monitor/accounts/myAzureMonitorWorkspace"
+          ],
+          "rules": [
+            {
+              "record": "job_type:billing_jobs_duration_seconds:99p5m",
+              "expression": "histogram_quantile(0.99, sum(rate(jobs_duration_seconds_bucket{service=\"billing-processing\"}[5m])) by (job_type))",
+              "labels": {
+                "team": "prod"
+              }
+            },
+            {
+              "alert": "Billing_Processing_Very_Slow",
+              "expression": "job_type:billing_jobs_duration_seconds:99p5m > 30",
+              "enabled": true,
+              "severity": 2,
+              "for": "PT5M",
+              "labels": {
+                "team": "prod"
+              },
+              "annotations": {
+                "annotationName1": "annotationValue1"
+              },
+              "resolveConfiguration": {
+                "autoResolved": true,
+                "timeToResolve": "PT10M"
+              },
+              "actions": [
+                {
+                  "actionGroupId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourcegroups/myrg/providers/microsoft.insights/actiongroups/myactiongroup",
+                  "actionProperties": {
+                    "key11": "value11",
+                    "key12": "value12"
+                  }
+                },
+                {
+                  "actionGroupId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourcegroups/myrg/providers/microsoft.insights/actiongroups/myotheractiongroup",
+                  "actionProperties": {
+                    "key21": "value21",
+                    "key22": "value22"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "201": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/promResourceGroup/providers/Microsoft.AlertsManagement/prometheusRuleGroups/myPrometheusRuleGroup",
+        "type": "Microsoft.AlertsManagement/prometheusRuleGroups",
+        "location": "East US",
+        "properties": {
+          "description": "This is the description of the following rule group",
+          "enabled": true,
+          "interval": "PT10M",
+          "clusterName": "myClusterName",
+          "scopes": [
+            "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/myResourceGroup/providers/microsoft.monitor/accounts/myAzureMonitorWorkspace"
+          ],
+          "rules": [
+            {
+              "record": "job_type:billing_jobs_duration_seconds:99p5m",
+              "expression": "histogram_quantile(0.99, sum(rate(jobs_duration_seconds_bucket{service=\"billing-processing\"}[5m])) by (job_type))",
+              "labels": {
+                "team": "prod"
+              }
+            },
+            {
+              "alert": "Billing_Processing_Very_Slow",
+              "expression": "job_type:billing_jobs_duration_seconds:99p5m > 30",
+              "enabled": true,
+              "severity": 2,
+              "for": "PT5M",
+              "labels": {
+                "team": "prod"
+              },
+              "annotations": {
+                "annotationName1": "annotationValue1"
+              },
+              "resolveConfiguration": {
+                "autoResolved": true,
+                "timeToResolve": "PT10M"
+              },
+              "actions": [
+                {
+                  "actionGroupId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourcegroups/myrg/providers/microsoft.insights/actiongroups/myactiongroup",
+                  "actionProperties": {
+                    "key11": "value11",
+                    "key12": "value12"
+                  }
+                },
+                {
+                  "actionGroupId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourcegroups/myrg/providers/microsoft.insights/actiongroups/myotheractiongroup",
+                  "actionProperties": {
+                    "key21": "value21",
+                    "key22": "value22"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2024-05-01/examples/deletePrometheusRuleGroup.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2024-05-01/examples/deletePrometheusRuleGroup.json
@@ -1,0 +1,12 @@
+{
+  "parameters": {
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+    "resourceGroupName": "promResourceGroup",
+    "ruleGroupName": "myPrometheusRuleGroup",
+    "api-version": "2024-05-01"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  }
+}

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2024-05-01/examples/getPrometheusRuleGroup.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2024-05-01/examples/getPrometheusRuleGroup.json
@@ -1,0 +1,69 @@
+{
+  "parameters": {
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+    "resourceGroupName": "promResourceGroup",
+    "ruleGroupName": "myPrometheusRuleGroup",
+    "api-version": "2024-05-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/promResourceGroup/providers/Microsoft.AlertsManagement/prometheusRuleGroups/myPrometheusRuleGroup",
+        "type": "Microsoft.AlertsManagement/prometheusRuleGroups",
+        "location": "East US",
+        "properties": {
+          "description": "This is the description of the following rule group",
+          "enabled": true,
+          "interval": "PT10M",
+          "clusterName": "myClusterName",
+          "scopes": [
+            "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/myResourceGroup/providers/microsoft.monitor/accounts/myAzureMonitorWorkspace"
+          ],
+          "rules": [
+            {
+              "record": "job_type:billing_jobs_duration_seconds:99p5m",
+              "expression": "histogram_quantile(0.99, sum(rate(jobs_duration_seconds_bucket{service=\"billing-processing\"}[5m])) by (job_type))",
+              "labels": {
+                "team": "prod"
+              }
+            },
+            {
+              "alert": "Billing_Processing_Very_Slow",
+              "expression": "job_type:billing_jobs_duration_seconds:99p5m > 30",
+              "enabled": true,
+              "severity": 2,
+              "for": "PT5M",
+              "labels": {
+                "team": "prod"
+              },
+              "annotations": {
+                "annotationName1": "annotationValue1"
+              },
+              "resolveConfiguration": {
+                "autoResolved": true,
+                "timeToResolve": "PT10M"
+              },
+              "actions": [
+                {
+                  "actionGroupId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourcegroups/myrg/providers/microsoft.insights/actiongroups/myactiongroup",
+                  "actionProperties": {
+                    "key11": "value11",
+                    "key12": "value12"
+                  }
+                },
+                {
+                  "actionGroupId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourcegroups/myrg/providers/microsoft.insights/actiongroups/myotheractiongroup",
+                  "actionProperties": {
+                    "key21": "value21",
+                    "key22": "value22"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2024-05-01/examples/listPrometheusRuleGroups.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2024-05-01/examples/listPrometheusRuleGroups.json
@@ -1,0 +1,128 @@
+{
+  "parameters": {
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+    "resourceGroupName": "promResourceGroup",
+    "api-version": "2024-05-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/promResourceGroup/providers/Microsoft.AlertsManagement/prometheusRuleGroups/ruleGroupName1",
+            "type": "Microsoft.AlertsManagement/prometheusRuleGroups",
+            "location": "East US",
+            "properties": {
+              "description": "This is the description of the following rule group",
+              "enabled": true,
+              "interval": "PT10M",
+              "clusterName": "myClusterName",
+              "scopes": [
+                "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/myResourceGroup/providers/microsoft.monitor/accounts/myAzureMonitorWorkspace"
+              ],
+              "rules": [
+                {
+                  "record": "job_type:billing_jobs_duration_seconds:99p5m",
+                  "expression": "histogram_quantile(0.99, sum(rate(jobs_duration_seconds_bucket{service=\"billing-processing\"}[5m])) by (job_type))",
+                  "labels": {
+                    "team": "prod"
+                  }
+                },
+                {
+                  "alert": "Billing_Processing_Very_Slow",
+                  "expression": "job_type:billing_jobs_duration_seconds:99p5m > 30",
+                  "enabled": true,
+                  "severity": 2,
+                  "for": "PT5M",
+                  "labels": {
+                    "team": "prod"
+                  },
+                  "annotations": {
+                    "annotationName1": "annotationValue1"
+                  },
+                  "resolveConfiguration": {
+                    "autoResolved": true,
+                    "timeToResolve": "PT10M"
+                  },
+                  "actions": [
+                    {
+                      "actionGroupId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourcegroups/myrg/providers/microsoft.insights/actiongroups/myactiongroup",
+                      "actionProperties": {
+                        "key11": "value11",
+                        "key12": "value12"
+                      }
+                    },
+                    {
+                      "actionGroupId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourcegroups/myrg/providers/microsoft.insights/actiongroups/myotheractiongroup",
+                      "actionProperties": {
+                        "key21": "value21",
+                        "key22": "value22"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/promResourceGroup/providers/Microsoft.AlertsManagement/prometheusRuleGroups/ruleGroupName2",
+            "type": "Microsoft.AlertsManagement/prometheusRuleGroups",
+            "location": "East US",
+            "properties": {
+              "description": "This is the description of the following rule group",
+              "enabled": true,
+              "interval": "PT10M",
+              "clusterName": "myClusterName",
+              "scopes": [
+                "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/myResourceGroup/providers/microsoft.monitor/accounts/myAzureMonitorWorkspace"
+              ],
+              "rules": [
+                {
+                  "record": "job_type:billing_jobs_duration_seconds:99p5m",
+                  "expression": "histogram_quantile(0.99, sum(rate(jobs_duration_seconds_bucket{service=\"billing-processing\"}[5m])) by (job_type))",
+                  "labels": {
+                    "team": "prod"
+                  }
+                },
+                {
+                  "alert": "Billing_Processing_Very_Slow",
+                  "expression": "job_type:billing_jobs_duration_seconds:99p5m > 30",
+                  "enabled": true,
+                  "severity": 2,
+                  "for": "PT5M",
+                  "labels": {
+                    "team": "prod"
+                  },
+                  "annotations": {
+                    "annotationName1": "annotationValue1"
+                  },
+                  "resolveConfiguration": {
+                    "autoResolved": true,
+                    "timeToResolve": "PT10M"
+                  },
+                  "actions": [
+                    {
+                      "actionGroupId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourcegroups/myrg/providers/microsoft.insights/actiongroups/myactiongroup",
+                      "actionProperties": {
+                        "key11": "value11",
+                        "key12": "value12"
+                      }
+                    },
+                    {
+                      "actionGroupId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourcegroups/myrg/providers/microsoft.insights/actiongroups/myotheractiongroup",
+                      "actionProperties": {
+                        "key21": "value21",
+                        "key22": "value22"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2024-05-01/examples/listSubscriptionPrometheusRuleGroups.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2024-05-01/examples/listSubscriptionPrometheusRuleGroups.json
@@ -1,0 +1,128 @@
+{
+  "parameters": {
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+    "resourceGroupName": "promResourceGroup",
+    "api-version": "2024-05-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourceGroupName1/providers/Microsoft.AlertsManagement/prometheusRuleGroups/myPrometheusRuleGroup",
+            "type": "Microsoft.AlertsManagement/prometheusRuleGroups",
+            "location": "East US",
+            "properties": {
+              "description": "This is the description of the following rule group",
+              "enabled": true,
+              "interval": "PT10M",
+              "clusterName": "myClusterName",
+              "scopes": [
+                "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/myResourceGroup/providers/microsoft.monitor/accounts/myAzureMonitorWorkspace"
+              ],
+              "rules": [
+                {
+                  "record": "job_type:billing_jobs_duration_seconds:99p5m",
+                  "expression": "histogram_quantile(0.99, sum(rate(jobs_duration_seconds_bucket{service=\"billing-processing\"}[5m])) by (job_type))",
+                  "labels": {
+                    "team": "prod"
+                  }
+                },
+                {
+                  "alert": "Billing_Processing_Very_Slow",
+                  "expression": "job_type:billing_jobs_duration_seconds:99p5m > 30",
+                  "enabled": true,
+                  "severity": 2,
+                  "for": "PT5M",
+                  "labels": {
+                    "team": "prod"
+                  },
+                  "annotations": {
+                    "annotationName1": "annotationValue1"
+                  },
+                  "resolveConfiguration": {
+                    "autoResolved": true,
+                    "timeToResolve": "PT10M"
+                  },
+                  "actions": [
+                    {
+                      "actionGroupId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourcegroups/myrg/providers/microsoft.insights/actiongroups/myactiongroup",
+                      "actionProperties": {
+                        "key11": "value11",
+                        "key12": "value12"
+                      }
+                    },
+                    {
+                      "actionGroupId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourcegroups/myrg/providers/microsoft.insights/actiongroups/myotheractiongroup",
+                      "actionProperties": {
+                        "key21": "value21",
+                        "key22": "value22"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/resourceGroupName2/providers/Microsoft.AlertsManagement/prometheusRuleGroups/myPrometheusRuleGroup",
+            "type": "Microsoft.AlertsManagement/prometheusRuleGroups",
+            "location": "East US",
+            "properties": {
+              "description": "This is the description of the following rule group",
+              "enabled": true,
+              "interval": "PT10M",
+              "clusterName": "myClusterName",
+              "scopes": [
+                "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/myResourceGroup/providers/microsoft.monitor/accounts/myAzureMonitorWorkspace"
+              ],
+              "rules": [
+                {
+                  "record": "job_type:billing_jobs_duration_seconds:99p5m",
+                  "expression": "histogram_quantile(0.99, sum(rate(jobs_duration_seconds_bucket{service=\"billing-processing\"}[5m])) by (job_type))",
+                  "labels": {
+                    "team": "prod"
+                  }
+                },
+                {
+                  "alert": "Billing_Processing_Very_Slow",
+                  "expression": "job_type:billing_jobs_duration_seconds:99p5m > 30",
+                  "enabled": true,
+                  "severity": 2,
+                  "for": "PT5M",
+                  "labels": {
+                    "team": "prod"
+                  },
+                  "annotations": {
+                    "annotationName1": "annotationValue1"
+                  },
+                  "resolveConfiguration": {
+                    "autoResolved": true,
+                    "timeToResolve": "PT10M"
+                  },
+                  "actions": [
+                    {
+                      "actionGroupId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourcegroups/myrg/providers/microsoft.insights/actiongroups/myactiongroup",
+                      "actionProperties": {
+                        "key11": "value11",
+                        "key12": "value12"
+                      }
+                    },
+                    {
+                      "actionGroupId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourcegroups/myrg/providers/microsoft.insights/actiongroups/myotheractiongroup",
+                      "actionProperties": {
+                        "key21": "value21",
+                        "key22": "value22"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2024-05-01/examples/patchPrometheusRuleGroup.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2024-05-01/examples/patchPrometheusRuleGroup.json
@@ -1,0 +1,80 @@
+{
+  "parameters": {
+    "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+    "resourceGroupName": "promResourceGroup",
+    "ruleGroupName": "myPrometheusRuleGroup",
+    "api-version": "2024-05-01",
+    "parameters": {
+      "tags": {
+        "tag1": "tagValueFromPatch"
+      },
+      "properties": {
+        "enabled": false
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/promResourceGroup/providers/Microsoft.AlertsManagement/prometheusRuleGroups/myPrometheusRuleGroup",
+        "type": "Microsoft.AlertsManagement/prometheusRuleGroups",
+        "location": "East US",
+        "properties": {
+          "description": "This is the description of the following rule group",
+          "enabled": false,
+          "interval": "PT10M",
+          "clusterName": "myClusterName",
+          "scopes": [
+            "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/myResourceGroup/providers/microsoft.monitor/accounts/myAzureMonitorWorkspace"
+          ],
+          "rules": [
+            {
+              "record": "job_type:billing_jobs_duration_seconds:99p5m",
+              "expression": "histogram_quantile(0.99, sum(rate(jobs_duration_seconds_bucket{service=\"billing-processing\"}[5m])) by (job_type))",
+              "labels": {
+                "team": "prod"
+              }
+            },
+            {
+              "alert": "Billing_Processing_Very_Slow",
+              "expression": "job_type:billing_jobs_duration_seconds:99p5m > 30",
+              "enabled": true,
+              "severity": 2,
+              "for": "PT5M",
+              "labels": {
+                "team": "prod"
+              },
+              "annotations": {
+                "annotationName1": "annotationValue1"
+              },
+              "resolveConfiguration": {
+                "autoResolved": true,
+                "timeToResolve": "PT10M"
+              },
+              "actions": [
+                {
+                  "actionGroupId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourcegroups/myrg/providers/microsoft.insights/actiongroups/myactiongroup",
+                  "actionProperties": {
+                    "key11": "value11",
+                    "key12": "value12"
+                  }
+                },
+                {
+                  "actionGroupId": "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourcegroups/myrg/providers/microsoft.insights/actiongroups/myotheractiongroup",
+                  "actionProperties": {
+                    "key21": "value21",
+                    "key22": "value22"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "tags": {
+          "tag1": "tagValueFromPatch"
+        }
+      }
+    }
+  }
+}

--- a/specification/alertsmanagement/resource-manager/readme.md
+++ b/specification/alertsmanagement/resource-manager/readme.md
@@ -44,7 +44,20 @@ directive:
 title: AlertsManagementClient
 description: AlertsManagement Client
 openapi-type: arm
-tag: package-2023-03
+tag: package-2024-05
+```
+
+### Tag: package-2024-05
+
+These settings apply only when `--tag=package-2024-05` is specified on the command line.
+
+```yaml $(tag) == 'package-2024-05'
+input-file:
+  - Microsoft.AlertsManagement/stable/2024-05-01/PrometheusRuleGroups.json
+  - Microsoft.AlertsManagement/preview/2024-01-01-preview/AlertsManagement.json
+  - Microsoft.AlertsManagement/preview/2019-05-05-preview/SmartGroups.json
+  - Microsoft.AlertsManagement/preview/2023-08-01-preview/AlertRuleRecommendations.json
+  - Microsoft.AlertsManagement/preview/2024-03-01-preview/AlertProcessingRules.json
 ```
 
 ### Tag: package-preview-2024-03


### PR DESCRIPTION
DO NOT REVIEW! This is a test PR created by kojamroz from branch `brInfo_cross_ver_brch`.

## Information about this PR extracted from `BRANCH_INFO.md`

This branch was created by kojamroz on 6/26/2024

This branch is expected to trigger cross-version breaking change report between stable version. 
In addition, the TypeSpec requirement check should not trigger.

It differs from main as follows:

## 1. It introduces a new directory:

`specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2024-05-01`

which is a copy of:

`specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2023-03-01`

## 2. In the new directory the following file:

`specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/stable/2024-05-01/PrometheusRuleGroups.json`

Differs from its original. Its `operationId` has been changed. It is now:

`"operationId": "CROSS_VER_BREAKING_CHANGE_TEST_PrometheusRuleGroups_ListBySubscription",`

instead of the original:

`"operationId": "PrometheusRuleGroups_ListBySubscription",`

In addition, all files in the newly introduced directory got their `"version"` updated to be `"2024-05-01"`.

## 3. The README:

`specification/alertsmanagement/resource-manager/readme.md`

The default tag has been changed to `package-2024-05` and following entry was added:

> Tag: package-2024-05
> 
> These settings apply only when `--tag=package-2024-05` is specified on the command line.
>
> ```yaml $(tag) == 'package-2023-03'
> input-file:
>   - Microsoft.AlertsManagement/stable/2024-05-01/PrometheusRuleGroups.json
>   - Microsoft.AlertsManagement/preview/2024-01-01-preview/AlertsManagement.json
>   - Microsoft.AlertsManagement/preview/2019-05-05-preview/SmartGroups.json
>   - Microsoft.AlertsManagement/preview/2023-08-01-preview/AlertRuleRecommendations.json
>   - Microsoft.AlertsManagement/preview/2024-03-01-preview/AlertProcessingRules.json
> ```